### PR TITLE
Refactor/pokemon detail overview view

### DIFF
--- a/PokedexProject.xcodeproj/project.pbxproj
+++ b/PokedexProject.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8386645D2BD813DB00DA3D37 /* Locale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8386645C2BD813DB00DA3D37 /* Locale.swift */; };
 		E10EE6A02BD1FE7B00022EE7 /* OggDecoder in Frameworks */ = {isa = PBXBuildFile; productRef = E10EE69F2BD1FE7B00022EE7 /* OggDecoder */; };
 		E10EE6A22BD258F700022EE7 /* PokemonSpriteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10EE6A12BD258F700022EE7 /* PokemonSpriteView.swift */; };
 		E16ACA0D2BD7F70800F9A1BC /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16ACA0C2BD7F70800F9A1BC /* Extensions.swift */; };
@@ -29,6 +30,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		8386645C2BD813DB00DA3D37 /* Locale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locale.swift; sourceTree = "<group>"; };
 		E10EE6A12BD258F700022EE7 /* PokemonSpriteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonSpriteView.swift; sourceTree = "<group>"; };
 		E16ACA0C2BD7F70800F9A1BC /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		E16ACA0E2BD7FCD400F9A1BC /* Comments */ = {isa = PBXFileReference; lastKnownFileType = text; path = Comments; sourceTree = "<group>"; };
@@ -125,6 +127,7 @@
 			isa = PBXGroup;
 			children = (
 				E1D43A8C2BD1480100DF5ADB /* APIModel.swift */,
+				8386645C2BD813DB00DA3D37 /* Locale.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -246,6 +249,7 @@
 				E1D43A8D2BD1480100DF5ADB /* APIModel.swift in Sources */,
 				E1D43A992BD157DE00DF5ADB /* Singletones.swift in Sources */,
 				E1D43A972BD1495200DF5ADB /* EntryViewModel.swift in Sources */,
+				8386645D2BD813DB00DA3D37 /* Locale.swift in Sources */,
 				E1A7B3C72BD6468F001D914B /* PokemonMoveModalView.swift in Sources */,
 				E1BDEB732BD4F5CE004E0921 /* MainTabView.swift in Sources */,
 				E10EE6A22BD258F700022EE7 /* PokemonSpriteView.swift in Sources */,

--- a/PokedexProject/Models/APIModel.swift
+++ b/PokedexProject/Models/APIModel.swift
@@ -112,11 +112,19 @@ struct PokemonSpeciesData: Identifiable, Codable {
 
 struct PokemonGlobalName: Codable {
     let name: String
+    let language: Language
 }
 
 struct PokemonGenera: Codable {
     let genus: String
+    let language: Language
 }
+
+struct Language: Codable {
+    let name: String
+    let url: String
+}
+
 
 //MARK: 폭행몬 기술 상세 https://pokeapi.co/api/v2/move/5/
 struct PokemonMoveDetailExtended: Codable {

--- a/PokedexProject/Models/Locale.swift
+++ b/PokedexProject/Models/Locale.swift
@@ -1,0 +1,33 @@
+//
+//  Locale.swift
+//  PokedexProject
+//
+//  Created by jinwoong Kim on 4/24/24.
+//
+
+import Foundation
+
+enum Locale: String, Identifiable {
+    var id: Self { self }
+    
+    case ko
+    case jp
+    case cn
+    case de
+    case en
+    
+    var accessName: String {
+        switch self {
+            case .ko:
+                return "ko"
+            case .jp:
+                return "ja-Hrkt"
+            case .cn:
+                return "zh-Hant"
+            case .de:
+                return "de"
+            case .en:
+                return "en"
+        }
+    }
+}

--- a/PokedexProject/View/DetailView/PokemonDetailOverviewView.swift
+++ b/PokedexProject/View/DetailView/PokemonDetailOverviewView.swift
@@ -10,8 +10,6 @@ import AVFoundation
 import OggDecoder
 
 struct PokemonDetailOverviewView: View {
-    
-    @Binding var localizationIndex: (nameIndex: Int, nickIndex: Int)
     @Binding var showingIrochiPortrait: Bool
     let localization: Locale
     
@@ -103,16 +101,6 @@ struct PokemonDetailOverviewView: View {
             })
         }
         
-        //MARK: 별명
-//        if let genus = viewModel.pokemonSpeciesData?.genera[safe: localizationIndex.nickIndex]?.genus {
-//            Text("\(genus)")
-//                .font(.system(size: 12))
-//                .fontWeight(.bold)
-//                .foregroundStyle(Color.gray)
-//                .padding(EdgeInsets(top: -10, leading: 0, bottom: 10, trailing: 0))
-//        }
-        
-        
         Rectangle()
             .frame(width: 20, height: 3, alignment: .center)
             .offset(y: -2)
@@ -194,8 +182,9 @@ extension PokemonDetailOverviewView {
 }
 
 #Preview {
-    PokemonDetailOverviewView(localizationIndex: .constant((nameIndex: 1, nickIndex: 1)),
-                              showingIrochiPortrait: .constant(false),
-                              localization: .ko,
-                              viewModel: PokemonDataViewModel())
+    PokemonDetailOverviewView(
+        showingIrochiPortrait: .constant(false),
+        localization: .ko,
+        viewModel: PokemonDataViewModel()
+    )
 }

--- a/PokedexProject/View/DetailView/PokemonDetailOverviewView.swift
+++ b/PokedexProject/View/DetailView/PokemonDetailOverviewView.swift
@@ -13,6 +13,7 @@ struct PokemonDetailOverviewView: View {
     
     @Binding var localizationIndex: (nameIndex: Int, nickIndex: Int)
     @Binding var showingIrochiPortrait: Bool
+    let localization: Locale
     
     @State var audioPlayer: AVAudioPlayer!
     
@@ -63,12 +64,13 @@ struct PokemonDetailOverviewView: View {
         
         //MARK: 이름, 울음소리, 이로치전환
         HStack {
-            //이름
-//            Text(String(viewModel.pokemonSpeciesData?.names[localizationIndex.nameIndex].name.capitalized ?? ""))
-            Text(String(viewModel.pokemonSpeciesData?.names[7].name.capitalized ?? ""))
-                .fontWeight(.heavy)
-                .font(Font.system(size: 28))
-                .baselineOffset(localizationIndex.nameIndex < 4 || localizationIndex.nameIndex == 10 ? -2.0 : 0.0)
+            VStack {
+                //이름
+                Text(viewModel.retrieveLocalName(from: localization) ?? "N/A")
+                
+                // 별칭
+                Text(viewModel.retrieveLocalGenus(from: localization) ?? "Sorry, we could not make it.")
+            }
             
             //울음소리
             Button(action: {
@@ -194,5 +196,6 @@ extension PokemonDetailOverviewView {
 #Preview {
     PokemonDetailOverviewView(localizationIndex: .constant((nameIndex: 1, nickIndex: 1)),
                               showingIrochiPortrait: .constant(false),
+                              localization: .ko,
                               viewModel: PokemonDataViewModel())
 }

--- a/PokedexProject/View/DetailView/PokemonDetailView.swift
+++ b/PokedexProject/View/DetailView/PokemonDetailView.swift
@@ -223,6 +223,8 @@ struct PokemonDetailView: View {
 }
 
 #Preview {
-    PokemonDetailView(pokeData: PokemonListObject(name: "pikachu", url: "https://pokeapi.co/api/v2/pokemon/25/"),
-                                endpoint: "https://pokeapi.co/api/v2/pokemon/25/")
+    NavigationStack {
+        PokemonDetailView(pokeData: PokemonListObject(name: "pikachu", url: "https://pokeapi.co/api/v2/pokemon/25/"),
+                                    endpoint: "https://pokeapi.co/api/v2/pokemon/25/")
+    }
 }

--- a/PokedexProject/View/DetailView/PokemonDetailView.swift
+++ b/PokedexProject/View/DetailView/PokemonDetailView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct PokemonDetailView: View {
     
     @State private var isModalShowing: Bool = false
-    @State private var localizationIndex: (nameIndex: Int, nickIndex: Int) = (8, 7)
     @State private var pokemonMoveData = [PokemonMoveData]()
     @State private var showingIrochiPortrait: Bool = false
     @State private var selectedMove: PokemonMoveDetail?
@@ -46,11 +45,11 @@ struct PokemonDetailView: View {
             //Content
             VStack {
                 //MARK: 넘버, 타입, 이름, 별명, 체중, 신장
-                PokemonDetailOverviewView(localizationIndex: $localizationIndex,
-                                          showingIrochiPortrait: $showingIrochiPortrait,
-                                          localization: selectedLocale,
-                                          viewModel: viewModel)
-                
+                PokemonDetailOverviewView(
+                    showingIrochiPortrait: $showingIrochiPortrait,
+                    localization: selectedLocale,
+                    viewModel: viewModel
+                )
                 
                 Divider()
                     .padding(.bottom, 10)
@@ -180,46 +179,6 @@ struct PokemonDetailView: View {
                 }
             }
         }
-//        .toolbar {
-//            ToolbarItem(placement: .topBarTrailing) {
-//                //다국어 이름정보
-//                Picker(selection: $localizationIndex.nameIndex) {
-//                    Text("English")
-//                        .tag(8)
-//                    Text("日本語")
-//                        .tag(0)
-//                    Text("한국어")
-//                        .tag(2)
-//                    Text("繁体字")
-//                        .tag(3)
-//                    Text("简体字")
-//                        .tag(10)
-//                    Text("Français")
-//                        .tag(4)
-//                    Text("Deutsch")
-//                        .tag(5)
-//                    Text("Español")
-//                        .tag(6)
-//                    Text("Italiano")
-//                        .tag(7)
-//                } label: {
-//                    Image(systemName: "globe")
-//                        .resizable()
-//                        .aspectRatio(contentMode: .fit)
-//                        .foregroundStyle(Color("textColor"))
-//                        .frame(width: 22, height: 22)
-//                        .offset(x: 5, y: 2)
-//                }
-//                .onChange(of: localizationIndex.nameIndex) { oldValue, newValue in
-//                    switch newValue {
-//                        case 0: //일본어
-//                            localizationIndex.nickIndex = 0
-//                        default: //그외 언어
-//                            localizationIndex.nickIndex = newValue - 1
-//                    }
-//                }
-//            }
-//        }
     }
     
 }

--- a/PokedexProject/View/DetailView/PokemonDetailView.swift
+++ b/PokedexProject/View/DetailView/PokemonDetailView.swift
@@ -14,6 +14,7 @@ struct PokemonDetailView: View {
     @State private var pokemonMoveData = [PokemonMoveData]()
     @State private var showingIrochiPortrait: Bool = false
     @State private var selectedMove: PokemonMoveDetail?
+    @State private var selectedLocale: Locale = .ko
     
     var viewModel: PokemonDataViewModel = PokemonDataViewModel()
     let pokeData: PokemonListObject

--- a/PokedexProject/View/DetailView/PokemonDetailView.swift
+++ b/PokedexProject/View/DetailView/PokemonDetailView.swift
@@ -47,8 +47,10 @@ struct PokemonDetailView: View {
             VStack {
                 //MARK: 넘버, 타입, 이름, 별명, 체중, 신장
                 PokemonDetailOverviewView(localizationIndex: $localizationIndex,
-                                          showingIrochiPortrait: $showingIrochiPortrait, 
+                                          showingIrochiPortrait: $showingIrochiPortrait,
+                                          localization: selectedLocale,
                                           viewModel: viewModel)
+                
                 
                 Divider()
                     .padding(.bottom, 10)

--- a/PokedexProject/View/DetailView/PokemonDetailView.swift
+++ b/PokedexProject/View/DetailView/PokemonDetailView.swift
@@ -154,6 +154,30 @@ struct PokemonDetailView: View {
                 opacity = 1
             }
         }
+        .toolbar {
+            ToolbarItem {
+                Picker(selection: $selectedLocale) {
+                    Text("한국어")
+                        .tag(Locale.ko)
+                    Text("일본어")
+                        .tag(Locale.jp)
+                    Text("영어")
+                        .tag(Locale.en)
+                    Text("중국어")
+                        .tag(Locale.cn)
+                    Text("독일어")
+                        .tag(Locale.de)
+                } label: {
+                    Image(systemName: "globe")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .foregroundStyle(Color("textColor"))
+                        .frame(width: 22, height: 22)
+                        .offset(x: 5, y: 2)
+
+                }
+            }
+        }
 //        .toolbar {
 //            ToolbarItem(placement: .topBarTrailing) {
 //                //다국어 이름정보

--- a/PokedexProject/View/DetailView/PokemonDetailViewModel.swift
+++ b/PokedexProject/View/DetailView/PokemonDetailViewModel.swift
@@ -15,6 +15,14 @@ class PokemonDataViewModel {
     private(set) var pokemonSpeciesData: PokemonSpeciesData?
     private(set) var pokemonMoveData: [PokemonMoveData]?
     
+    private var pokemonNames: [PokemonGlobalName] {
+        pokemonSpeciesData?.names ?? []
+    }
+    
+    private var pokemonGenera: [PokemonGenera] {
+        pokemonSpeciesData?.genera ?? []
+    }
+    
     var pokemonId: Int {
         pokemonData?.id ?? 1
     }

--- a/PokedexProject/View/DetailView/PokemonDetailViewModel.swift
+++ b/PokedexProject/View/DetailView/PokemonDetailViewModel.swift
@@ -139,3 +139,17 @@ class PokemonDataViewModel {
         }
     }
 }
+
+extension PokemonDataViewModel {
+    func retrieveLocalName(from locale: Locale) -> String? {
+        pokemonNames
+            .first { $0.language.name == locale.accessName }?
+            .name
+    }
+    
+    func retrieveLocalGenus(from locale: Locale) -> String? {
+        pokemonGenera
+            .first { $0.language.name == locale.accessName }?
+            .genus
+    }
+}


### PR DESCRIPTION
## Existing Issues

기존의 코드는 `https://pokeapi.co/api/v2/pokemon-species/$NUMBER`와 같은 api 호출로 부터 로컬라이징된 이름과 별칭을 얻어올 때, 고정된 인덱스를 통해 접근하여 값을 가져왔습니다. 이 approach은 초창기 포켓몬 세대에 해당하는 데이터에는 완벽하게 동작하였습니다. 대부분의 데이터는 아래와 같이 일본어-한국어-중국어... 순으로 데이터가 정렬되어 있음을 알 수 있습니다:
```json
"genera": [
    {
      "genus": "とかげポケモン",
      "language": {
        "name": "ja-Hrkt",
        "url": "https://pokeapi.co/api/v2/language/1/"
      }
    },
    {
      "genus": "도롱뇽포켓몬",
      "language": {
        "name": "ko",
        "url": "https://pokeapi.co/api/v2/language/3/"
      }
    },
    {
      "genus": "蜥蜴寶可夢",
      "language": {
        "name": "zh-Hant",
        "url": "https://pokeapi.co/api/v2/language/4/"
      }
    },
...
]
```
하지만 비교적 최신 세대의 포켓몬 데이터는 몇몇 국가의 언어가 누락되어 있습니다:
```json
"genera": [
    {
      "genus": "マジシャンポケモン",
      "language": {
        "name": "ja-Hrkt",
        "url": "https://pokeapi.co/api/v2/language/1/"
      }
    },
    {
      "genus": "魔術師寶可夢",
      "language": {
        "name": "zh-Hant",
        "url": "https://pokeapi.co/api/v2/language/4/"
      }
    },
    {
      "genus": "Magier",
      "language": {
        "name": "de",
        "url": "https://pokeapi.co/api/v2/language/6/"
      }
    },
...
]
```

이로 인한 기존의 접근 방식은 한국어 표기시 중국어가, 중국어 표기시 독일어가 나타나는 문제를 발생시킵니다.

## Proposed Solution
### Model Level
현재의 ViewModel은 네트워크 통신을 통하여 여러 언어로 번역된 포켓몬의 이름과 별칭을 가져오고 있습니다. 그곳에는 모두 해당 언어가 어떤 언어인지에 대한 정보를 함께 담고 있습니다:

```json
// in genera
{
      "genus": "とかげポケモン",
      "language": {
        "name": "ja-Hrkt",
        "url": "https://pokeapi.co/api/v2/language/1/"
      }
}

// in names
{
      "language": {
        "name": "ko",
        "url": "https://pokeapi.co/api/v2/language/3/"
      },
      "name": "파이리"
}
```
기존의 Swfit의 데이터 타입을 위의 언어 정보를 추가하면 다음과 같습니다:
```swift
struct PokemonGenera: Codable {
    let genus: String
    let language: Language
}

struct PokemonGlobalName: Codable {
    let name: String
    let language: Language
}

// new type
struct Language: Codable {
    let name: String
    let url: String
}
```
이제 여러 이름들과 별칭들의 배열을 `Language`타입의 `name`을 기준으로 값을 가져오거나(retrieve) 정렬할 수 있게 되었습니다.
```swift
func retrieveLocalName(with languageName: String) -> String? {
    let names = viewModel.pokemonSpeciesData.names
    return names.first { $0.language.name == languageName}
}

let result = retrieveLocalName(with: "ko")
```
리터럴한 "ko" 문자열을 사용하기 보다는 이를 열거형으로 관리하는 것이 좋아보입니다:
```swift
enum Locale: String, Identifiable {
    var id: Self { self }
    
    case ko
    case jp
    case cn
    case de
    case en
    
    var accessName: String {
        switch self {
            case .ko:
                return "ko"
            case .jp:
                return "ja-Hrkt"
            case .cn:
                return "zh-Hant"
            case .de:
                return "de"
            case .en:
                return "en"
        }
    }
}
```
이제 이 열거형을 통해 조건식을 작성할 수 있습니다:
```swift
func retrieveLocalName(from locale: Locale) -> String? {
    let names = viewModel.pokemonSpeciesData.names
    return names.first { $0.language.name == locale.accessName }
}

let result = retrieveLocalName(from: .ko)
```

### Presentation Level
기존의 toolbar 코드를 그대로 사용하고, `PokemonDetailOverviewView`에서 위의 메서드를 사용하여 현재 locale에 해당하는 포켓몬의 이름과 별칭을 가져오게 수정하였습니다:
```swift
// PokemonDetailOverviewView.swift
VStack {
    //이름
    Text(viewModel.retrieveLocalName(from: localization) ?? "N/A")
                
    // 별칭
    Text(viewModel.retrieveLocalGenus(from: localization) ?? "Sorry, we could not make it.")
}
```






| ![Korean](https://github.com/hellotunamayo/PokeDexProject/assets/26710036/66015aef-cb39-40f5-a495-d00fa89ea623) | ![English](https://github.com/hellotunamayo/PokeDexProject/assets/26710036/4516a062-ed13-4526-bd58-80eba3020603) |
|:--:|:--:|
| *Korean* | *English*
