### PR TITLE
Refactor/image reloading

### DIFF
--- a/PokedexProject.xcodeproj/project.pbxproj
+++ b/PokedexProject.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		8327346D2BDE1BED00E48303 /* EntryUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8327346C2BDE1BED00E48303 /* EntryUseCase.swift */; };
 		8327346F2BDE1CAB00E48303 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8327346E2BDE1CAB00E48303 /* Endpoint.swift */; };
 		832734712BDE308E00E48303 /* PokemonDataUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832734702BDE308E00E48303 /* PokemonDataUseCase.swift */; };
+		832734772BDEB6A800E48303 /* PokemonPortraitDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832734762BDEB6A800E48303 /* PokemonPortraitDispatcher.swift */; };
 		8386645D2BD813DB00DA3D37 /* Locale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8386645C2BD813DB00DA3D37 /* Locale.swift */; };
 		E10EE6A22BD258F700022EE7 /* PokemonSpriteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10EE6A12BD258F700022EE7 /* PokemonSpriteView.swift */; };
 		E11832292BDE070C00764E55 /* pokemonLocalNames.json in Resources */ = {isa = PBXBuildFile; fileRef = E11832282BDE070C00764E55 /* pokemonLocalNames.json */; };
@@ -61,6 +62,7 @@
 		8327346C2BDE1BED00E48303 /* EntryUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryUseCase.swift; sourceTree = "<group>"; };
 		8327346E2BDE1CAB00E48303 /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
 		832734702BDE308E00E48303 /* PokemonDataUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonDataUseCase.swift; sourceTree = "<group>"; };
+		832734762BDEB6A800E48303 /* PokemonPortraitDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonPortraitDispatcher.swift; sourceTree = "<group>"; };
 		8386645C2BD813DB00DA3D37 /* Locale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locale.swift; sourceTree = "<group>"; };
 		E10EE6A12BD258F700022EE7 /* PokemonSpriteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonSpriteView.swift; sourceTree = "<group>"; };
 		E11832282BDE070C00764E55 /* pokemonLocalNames.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = pokemonLocalNames.json; sourceTree = "<group>"; };
@@ -286,6 +288,7 @@
 				E1D43A962BD1495200DF5ADB /* EntryViewModel.swift */,
 				E1D43A7F2BD147C700DF5ADB /* EntryView.swift */,
 				E1BDEB662BD3F741004E0921 /* EntryViewCell.swift */,
+				832734762BDEB6A800E48303 /* PokemonPortraitDispatcher.swift */,
 			);
 			path = EntryView;
 			sourceTree = "<group>";
@@ -403,6 +406,7 @@
 				E1BDEB672BD3F741004E0921 /* EntryViewCell.swift in Sources */,
 				8327346F2BDE1CAB00E48303 /* Endpoint.swift in Sources */,
 				E16ACA0D2BD7F70800F9A1BC /* Extensions.swift in Sources */,
+				832734772BDEB6A800E48303 /* PokemonPortraitDispatcher.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PokedexProject/Models/APIModel.swift
+++ b/PokedexProject/Models/APIModel.swift
@@ -102,12 +102,38 @@ struct PokemonSpeciesData: Identifiable, Codable {
     let name: String
     let names: [PokemonGlobalName]
     let genera: [PokemonGenera]
+    let flavorTextEntries: [FlavorText]
     
     enum CodingKeys: String, CodingKey {
         case id, name, names, genera
         case baseHappiness = "base_happiness"
         case captureRate = "capture_rate"
+        case flavorTextEntries = "flavor_text_entries"
     }
+}
+
+struct FlavorText: Identifiable, Codable {
+    var id: UUID {
+        return UUID()
+    }
+    let flavorText: String
+    let language: FlavorTextLanguage
+    let version: FlavorTextVersion
+    
+    enum CodingKeys: String, CodingKey {
+        case language, version
+        case flavorText = "flavor_text"
+    }
+}
+
+struct FlavorTextVersion: Codable {
+    let name: String
+    let url: String
+}
+
+struct FlavorTextLanguage: Codable {
+    let name: String
+    let url: String
 }
 
 struct PokemonGlobalName: Codable {

--- a/PokedexProject/View/DetailView/PokemonDetailOverviewView.swift
+++ b/PokedexProject/View/DetailView/PokemonDetailOverviewView.swift
@@ -15,7 +15,7 @@ struct PokemonDetailOverviewView: View {
     
     @State var audioPlayer: AVAudioPlayer!
     
-    let viewModel: PokemonDataViewModel
+    let viewModel: PokemonDetailViewModel
     
     var body: some View {
         HStack {
@@ -192,6 +192,6 @@ extension PokemonDetailOverviewView {
     PokemonDetailOverviewView(
         showingIrochiPortrait: .constant(false),
         localization: .ko,
-        viewModel: PokemonDataViewModel()
+        viewModel: PokemonDetailViewModel()
     )
 }

--- a/PokedexProject/View/DetailView/PokemonDetailView.swift
+++ b/PokedexProject/View/DetailView/PokemonDetailView.swift
@@ -14,7 +14,7 @@ struct PokemonDetailView: View {
     
     @State private var selectedLocale: Locale = .en
     
-    var viewModel: PokemonDataViewModel = PokemonDataViewModel()
+    var viewModel: PokemonDetailViewModel = PokemonDetailViewModel()
     let pokeData: PokemonListObject
     let endpoint: String
     let gridItem: [GridItem] = [

--- a/PokedexProject/View/DetailView/PokemonDetailViewModel.swift
+++ b/PokedexProject/View/DetailView/PokemonDetailViewModel.swift
@@ -23,15 +23,11 @@ class PokemonDataViewModel {
         pokemonSpeciesData?.genera ?? []
     }
     
-    var pokemonId: Int {
-        pokemonData?.id ?? 1
-    }
-    
     @MainActor func fetch(urlString: String) async -> () {
         let result = await apiService.fetch(urlString: urlString)
         pokemonData = result
         pokemonMoveData = result?.moves ?? []
-        let speciesURLString = "https://pokeapi.co/api/v2/pokemon-species/\(pokemonId)"
+        let speciesURLString = "https://pokeapi.co/api/v2/pokemon-species/\(result?.id ?? 1)"
         pokemonSpeciesData = await apiService.fetchSpicies(urlString: speciesURLString)
     }
     

--- a/PokedexProject/View/DetailView/PokemonDetailViewModel.swift
+++ b/PokedexProject/View/DetailView/PokemonDetailViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 @Observable
-class PokemonDataViewModel {
+class PokemonDetailViewModel {
     private let apiService: some PokemonDetailUseCase = PokemonAPIService()
     private(set) var pokemonData: PokemonDetailData?
     private(set) var pokemonSpeciesData: PokemonSpeciesData?
@@ -114,7 +114,7 @@ class PokemonDataViewModel {
     }
 }
 
-extension PokemonDataViewModel {
+extension PokemonDetailViewModel {
     func retrieveLocalName(from locale: Locale) -> String? {
         pokemonNames
             .first { $0.language.name == locale.accessName }?

--- a/PokedexProject/View/DetailView/PokemonDetailViewModel.swift
+++ b/PokedexProject/View/DetailView/PokemonDetailViewModel.swift
@@ -28,10 +28,10 @@ class PokemonDataViewModel {
     }
     
     @MainActor func fetch(urlString: String) async -> () {
-        let speciesURLString = "https://pokeapi.co/api/v2/pokemon-species/\(pokemonId)"
         let result = await apiService.fetch(urlString: urlString)
         pokemonData = result
         pokemonMoveData = result?.moves ?? []
+        let speciesURLString = "https://pokeapi.co/api/v2/pokemon-species/\(pokemonId)"
         pokemonSpeciesData = await apiService.fetchSpicies(urlString: speciesURLString)
     }
     

--- a/PokedexProject/View/EntryView/EntryViewCell.swift
+++ b/PokedexProject/View/EntryView/EntryViewCell.swift
@@ -82,7 +82,12 @@ struct EntryViewCell: View {
                     }
                 }
                 .onAppear {
-                    pokemonPortraitDispatcher.load(with: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/\(index+1).png")
+                    if pokemonPortraitDispatcher.image == nil {
+                        pokemonPortraitDispatcher.load(with: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/\(index+1).png")
+                    }
+                }
+                .onDisappear {
+                    pokemonPortraitDispatcher.cancel()
                 }
                 .offset(x: proxy.frame(in: .local).maxX - (140 - portraitOffsetX), y: proxy.frame(in: .local).maxY - 140)
             }

--- a/PokedexProject/View/EntryView/EntryViewCell.swift
+++ b/PokedexProject/View/EntryView/EntryViewCell.swift
@@ -8,8 +8,7 @@
 import SwiftUI
 
 struct EntryViewCell: View {
-    
-    @State var backgroundColor: UIColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)
+    @StateObject var pokemonPortraitDispatcher = PokemonPortraitDispatcher()
     @State var portraitOffsetX: CGFloat = 50.0
     @State var cellOpacity: CGFloat = 0.0
     
@@ -20,7 +19,7 @@ struct EntryViewCell: View {
             s: CGFloat = 0.0,
             b: CGFloat = 0.0,
             a: CGFloat = 0.0
-        if backgroundColor.getHue(&h, saturation: &s, brightness: &b, alpha: &a) {
+        if pokemonPortraitDispatcher.backgroundColor.getHue(&h, saturation: &s, brightness: &b, alpha: &a) {
             b += 0.9
             b = max(min(b, 1.0), 0.0)
             return UIColor(hue: h, saturation: s, brightness: b, alpha: a)
@@ -34,7 +33,7 @@ struct EntryViewCell: View {
                 Rectangle()
                     .frame(width: 600, height: 300)
                     .foregroundStyle(
-                        Color(backgroundColor)
+                        Color(pokemonPortraitDispatcher.backgroundColor)
                             .opacity(0.2)
                     )
                     .rotationEffect(Angle(degrees: 60))
@@ -67,9 +66,9 @@ struct EntryViewCell: View {
                 }
                 
                 //MARK: 포켓몬 이미지
-                AsyncImage(url: URL(string: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/\(index+1).png")) { phase in
-                    if let image = phase.image {
-                        image
+                Group {
+                    if let image = pokemonPortraitDispatcher.image {
+                        Image(uiImage: image)
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .frame(width: 140, height: 140)
@@ -80,23 +79,17 @@ struct EntryViewCell: View {
                             }
                     } else {
                         ProgressView()
-                            .frame(width: 10, height: 140)
                     }
                 }
+                .onAppear {
+                    pokemonPortraitDispatcher.load(with: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/\(index+1).png")
+                }
                 .offset(x: proxy.frame(in: .local).maxX - (140 - portraitOffsetX), y: proxy.frame(in: .local).maxY - 140)
-                
             }
             .frame(minWidth: 200, maxWidth: .infinity)
             .clipShape(.rect)
-            .backgroundStyle(Color(backgroundColor))
-            .background(Color(backgroundColor).opacity(0.1))
-            .task {
-                do {
-                    backgroundColor = try await getColorFromImage(urlString: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/\(index+1).png")
-                } catch {
-                    print(error)
-                }
-            }
+            .backgroundStyle(Color(pokemonPortraitDispatcher.backgroundColor))
+            .background(Color(pokemonPortraitDispatcher.backgroundColor).opacity(0.1))
         }
         .opacity(cellOpacity)
         .background(Color.black)

--- a/PokedexProject/View/EntryView/PokemonPortraitDispatcher.swift
+++ b/PokedexProject/View/EntryView/PokemonPortraitDispatcher.swift
@@ -1,0 +1,106 @@
+//
+//  PokemonPortraitDispatcher.swift
+//  PokedexProject
+//
+//  Created by jinwoong Kim on 4/29/24.
+//
+
+import SwiftUI
+import Combine
+
+final class PokemonPortraitDispatcher: ObservableObject {
+    @Published private(set) var backgroundColor: UIColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)
+    @Published private(set) var image: UIImage?
+    
+    private let session: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        configuration.requestCachePolicy = .returnCacheDataElseLoad
+        return URLSession(configuration: configuration)
+    }()
+    
+    private var cancellable: AnyCancellable?
+    
+    func load(with imageUrlString: String) {
+        guard let imageUrl = URL(string: imageUrlString) else {
+            debugPrint("fail with bad url")
+            return
+        }
+        self.cancellable = session.dataTaskPublisher(for: imageUrl)
+            .tryMap { data, response in
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    throw HttpError.badResponse
+                }
+                guard httpResponse.statusCode == 200 else {
+                    throw HttpError.errorWith(code: httpResponse.statusCode, data: data)
+                }
+
+                return data
+            }
+            .map(combineImageAndColor(from:))
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                switch completion {
+                    case .finished:
+                        break
+                    case let .failure(error):
+                        debugPrint(error)
+                }
+            } receiveValue: { [weak self] color, image in
+                self?.backgroundColor = color
+                self?.image = image
+            }
+    }
+    
+    func cancel() {
+        cancellable?.cancel()
+    }
+    
+    private func combineImageAndColor(from imageData: Data) -> (UIColor, UIImage) {
+        let color = extractImageColor(from: imageData)
+        let image = UIImage(data: imageData) ?? UIImage()
+        
+        return (color, image)
+    }
+    
+    private func extractImageColor(from imageData: Data) -> UIColor {
+        guard let targetImage = CIImage(data: imageData) else { return UIColor() }
+        
+        let extentVector = CIVector(
+            x: targetImage.extent.minX,
+            y: targetImage.extent.minY,
+            z: targetImage.extent.width,
+            w: targetImage.extent.height
+        )
+        guard let filter = CIFilter(
+            name: "CIAreaAverage",
+            parameters: [
+                kCIInputImageKey: targetImage,
+                kCIInputExtentKey: extentVector
+            ]
+        ) else {
+            return UIColor()
+        }
+        
+        guard let outputImage = filter.outputImage else { return UIColor() }
+        var bitmap = [UInt8](repeating: 0, count: 4)
+        let context = CIContext(options: [.workingColorSpace: kCFNull!])
+        context.render(
+            outputImage,
+            toBitmap: &bitmap,
+            rowBytes: 4,
+            bounds: CGRect(x: 0, y: 0, width: 1, height: 1),
+            format: .RGBA8,
+            colorSpace: nil
+        )
+        
+        let redColor: CGFloat = CGFloat(bitmap[0]) / 25.5
+        let greenColor: CGFloat = CGFloat(bitmap[1]) / 25.5
+        let blueColor: CGFloat = CGFloat(bitmap[2]) / 25.5
+        return UIColor(
+            red: redColor > 1.0 ? 1.0 : redColor,
+            green: greenColor > 1.0 ? 1.0 : greenColor,
+            blue: blueColor > 1.0 ? 1.0 : blueColor,
+            alpha: 1
+        )
+    }
+}


### PR DESCRIPTION
# Existing Issues

기존의 코드에서 각 세대의 도감의 `EntryView`에 진입시, 각 cell들의 로딩에 문제가 발생했습니다. 아주 빠른 속도로 스크롤시, 몇몇 포켓몬의 초상화가 로딩이 되지않는 문제가 첫번째입니다.

<div align="center">
  <img src="https://github.com/hellotunamayo/PokeDexProject/assets/26710036/a3a20744-848f-4739-b139-380b266fc327" width="220" />
</div>

두번째는 동일한 URL에 대해 비동기 통신을 두번씩 진행한다는 점 입니다:
```swift
GeometryReader { proxy in 
    ...
    AsyncImage(url: POKEMON_URL)
    ...
}
.task {
    backgroundColor = try await getColorFromImage(url: POKEMON_URL)
}
```
첫번째 문제의 발생원인은 `AsyncImage`의 버그입니다. `AsyncImage`는 많은 양의 데이터를 표기해주는 `List`형태의 `View`에서 사용시 이미지가 로드되기전에 해당 이미지를 불러오는 `Task`가 cancel 되어버리는 버그가 존재합니다. 하지만 우리의 상황에서는 이것으로만 초래되진 않았습니다. 바로 두번째 문제점이 첫번째 문제점의 문제를 심화한다는 것 입니다. 위의 코드에서 `AsyncImage`와 `getColorFromImage(url:)` 메서드가 동시에 실행되는 시점엔 다음과 같은 `task cancellation error`를 출력하며 둘 중 하나의 테스크를 종료합니다:
```bash
Error Domain=NSURLErrorDomain Code=-999 "cancelled" ...
```
제 예상에는 `.task` 모디파이어는 view가 visible해지는 시점에 호출되므로, `getColorFromImage(url:)` 메서드가 실행됨으로써 거의 동시에(하지만 이보다는 이전에) 실행되는 task인 `AsyncImage`의 테스크가 취소되는 것으로 예상하고 있습니다. 그로 인해서 배경색은 정상적으로 로드되었으나, 그에 상응하는 포켓몬의 초상화는 로드되지 않았던 것 입니다.

# Proposed Solution
## Creating New Image Dispatcher

이를 해결하는 가장 직관적인 방법은 두번의 request 대신에 하나의 request로 이미지와 이미지의 색상을 모두 얻는 것 입니다. 안타깝게도 `AsyncImage`를 더 이상 사용할 수 없는 어프로치입니다.
```swift
GeometryReader { proxy in 
    ...
    // cannot use anymore
    // AsyncImage(url: POKEMON_URL) 
    ...
}
```

대신에, 이미지와 배경색을 퍼블리셔로 가지는 `ObservableObject`를 정의합니다. 이 객체는 프로퍼티로 `URLSession`을 가지고 있고, 이 `URLSession`의 `Configuration`으로 캐싱정책을 가지게합니다. 이 부분은 꽤나 중요해 보이는데, 왜냐하면 기존의 `AsyncImage`는 자체적으로 캐싱을 지원하기 때문입니다.
```swift
import Combine

final class PokemonPortraitDispatcher: ObservableObject {
    @Published private(set) var backgroundColor: UIColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)
    @Published private(set) var image: UIImage?
    
    private var cancellable: AnyCancellable?

    private let session: URLSession = {
        let configuration = URLSessionConfiguration.default
        configuration.requestCachePolicy = .returnCacheDataElseLoad
        return URLSession(configuration: configuration)
    }()
}
```
다음으로는 view가 appear되면 URL로 부터 이미지와 이미지 색상을 가져오는 메서드를 정의해야 합니다. appear되면 실행하고, disappear되면 실행되던 작업을 취소해야 하므로 `Combine`의 퍼블리셔와 `Swift Concurrency`의 `Task`를 사용하여 처리할 수 있을 것 같습니다. 이번에는 `Combine`을 사용해서 처리해보기로 했습니다.
1. imageUrlString을 인자로 받고 메서드를 호출하면 데이터 스트림이 생성되고 
2. 그 스트림을 통해 방출되는 값을 핸들링하여 UIImage와 UIColor로 변환하여 그것을 view에서 사용할 퍼블리셔에 할당하면 됩니다
```swift
func load(with imageUrlString: String) {
    guard let imageUrl = URL(string: imageUrlString) else {
        debugPrint("fail with bad url")
        return
    }
    self.cancellable = session.dataTaskPublisher(for: imageUrl)
        .tryMap { data, response in
            guard let httpResponse = response as? HTTPURLResponse else {
                throw HttpError.badResponse
            }
            guard httpResponse.statusCode == 200 else {
                throw HttpError.errorWith(code: httpResponse.statusCode, data: data)
            }

            return data
        }
        .map(combineImageAndColor(from:))
        .receive(on: DispatchQueue.main)
        .sink { completion in
            switch completion {
                case .finished:
                    break
                case let .failure(error):
                    debugPrint(error)
            }
        } receiveValue: { [weak self] color, image in
            self?.backgroundColor = color
            self?.image = image
        }
}
```
`tryMap` 오퍼레이터를 통해 image data를 받아오는 과정에서 발생할 수 있는 에러를 핸들링하고, `map` 오퍼레이터를 통해 `UIColor`와 `UIImage`를 방출하는 스트림으로 변환합니다. view 업데이트는 메인큐에서 진행해야 하기 때문에 다운스트림의 스케줄러를 `main`으로 변경합니다. 마지막으로 `sink`를 통한 구독으로 에러가 발생했다면 에러를 확인하고 값이 정상적으로 도달되었다면 값을 `@Published` 퍼블리셔들에게 할당합니다.

## Usage in View
View에서 사용할 땐, 기존의 `AsyncImage` 자리에 조건에 따라 일반 `Image` view와 `ProgressView`를 보여주는 `Group`을 배치하면 됩니다. 해당 조건은 `PokemonPortraitDispatcher` 객체의 image가 `nil`인지 아닌지에 따라 나뉩니다:
```swift
Group {
    if let image = pokemonPortraitDispatcher.image {
        Image(uiImage: image)
    } else {
        ProgressView()
    }
}
```
그리고 view가 appear가 되면 load(with:) 메서드를 실행시켜 이미지와 배경색을 구합니다:
```swift
Group {
    ...
}
.onAppear {
    if pokemonPortraitDispatcher.image == nil {
        pokemonPortraitDispatcher.load(
            with: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/\(index+1).png"
        )
    }
}
```
현재 우리의 cell view는 lazy하게 로딩되고 있습니다. 스크롤에 따라서 화면에 나타나기전에 view가 disappear되면 스트림을 종료하는 코드도 필요합니다:
```swift
Group {
    ...
}
.onAppear {
    ...
}
.onDisappear {
    pokemonPortraitDispatcher.cancel()
}
```
이를 통해, 우리는 동일한 url에 대한 요청을 동시에 2번하여 발생하는 문제를 해결했습니다!

<div align="center">
  <img src="https://github.com/hellotunamayo/PokeDexProject/assets/26710036/e386918f-7fa3-4303-9289-7fcb56ebc981" />
</div>


# Remaining Problem
아직 모든게 해결된 것은 아닙니다. 현재는 `PokemonPortraitDispatcher`를 `ObservableObject`를 채택하여 구성하였는데, 이는 `Observable` 매크로를 사용했을 때는 정상적으로 동작하지 않았기 때문입니다. 정확한 이유는 아직 모르겠습니다. 이후에 문제에 대한 원인이 발견되면 추가 작성하겠습니다.