### PR TITLE
Refactor/remove duplicated dependency

### DIFF
--- a/PokedexProject.xcodeproj/project.pbxproj
+++ b/PokedexProject.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		830D725C2BF3B9CB00D04E1E /* PokemonAPIServiceEnvironmentKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830D725B2BF3B9CB00D04E1E /* PokemonAPIServiceEnvironmentKey.swift */; };
 		8327344E2BDE0DCC00E48303 /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8327344D2BDE0DCC00E48303 /* APIService.swift */; };
 		832734502BDE0E0200E48303 /* Requestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8327344F2BDE0E0200E48303 /* Requestable.swift */; };
 		832734532BDE0E5700E48303 /* MIMEType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832734522BDE0E5700E48303 /* MIMEType.swift */; };
@@ -55,6 +56,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		830D725B2BF3B9CB00D04E1E /* PokemonAPIServiceEnvironmentKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonAPIServiceEnvironmentKey.swift; sourceTree = "<group>"; };
 		8327344D2BDE0DCC00E48303 /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
 		8327344F2BDE0E0200E48303 /* Requestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Requestable.swift; sourceTree = "<group>"; };
 		832734522BDE0E5700E48303 /* MIMEType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIMEType.swift; sourceTree = "<group>"; };
@@ -153,6 +155,7 @@
 			isa = PBXGroup;
 			children = (
 				832734662BDE19A200E48303 /* PokemonAPIService.swift */,
+				830D725B2BF3B9CB00D04E1E /* PokemonAPIServiceEnvironmentKey.swift */,
 			);
 			path = Impl;
 			sourceTree = "<group>";
@@ -428,6 +431,7 @@
 				E1BDEB672BD3F741004E0921 /* EntryViewCell.swift in Sources */,
 				E15B90212BE654F70037FC7C /* FavoriteView.swift in Sources */,
 				8327346F2BDE1CAB00E48303 /* Endpoint.swift in Sources */,
+				830D725C2BF3B9CB00D04E1E /* PokemonAPIServiceEnvironmentKey.swift in Sources */,
 				E16ACA0D2BD7F70800F9A1BC /* Extensions.swift in Sources */,
 				832734772BDEB6A800E48303 /* PokemonPortraitDispatcher.swift in Sources */,
 				E1666AF32BDFB6BF00D5EEFA /* PokemonDetailFlavorTextView.swift in Sources */,

--- a/PokedexProject/Network/Impl/PokemonAPIServiceEnvironmentKey.swift
+++ b/PokedexProject/Network/Impl/PokemonAPIServiceEnvironmentKey.swift
@@ -1,0 +1,19 @@
+//
+//  PokemonAPIServiceEnvironmentKey.swift
+//  PokedexProject
+//
+//  Created by jinwoong Kim on 5/15/24.
+//
+
+import SwiftUI
+
+struct PokemonAPIServiceEnvironmentKey: EnvironmentKey {
+    static var defaultValue: PokemonAPIService = .init()
+}
+
+extension EnvironmentValues {
+    var pokemonAPIService: PokemonAPIService {
+        get { self[PokemonAPIServiceEnvironmentKey.self] }
+        set { self[PokemonAPIServiceEnvironmentKey.self] = newValue }
+    }
+}

--- a/PokedexProject/View/DetailView/PokemonDetailGraphView.swift
+++ b/PokedexProject/View/DetailView/PokemonDetailGraphView.swift
@@ -16,11 +16,12 @@ struct PokemonDetailGraphView: View {
     @State private var offsetY: CGFloat = 30.0
     @State private var opacity: CGFloat = 0.0
     
-    let pokeStats: [PokemonStat]
-    let gridItem: [GridItem] = [
+    private let gridItem: [GridItem] = [
         GridItem(.flexible(minimum: 30, maximum: 300)),
         GridItem(.flexible(minimum: 30, maximum: 300))
     ]
+    
+    let pokeStats: [PokemonStat]
     
     var body: some View {
         LazyVGrid(columns: gridItem){

--- a/PokedexProject/View/DetailView/PokemonDetailOverviewView.swift
+++ b/PokedexProject/View/DetailView/PokemonDetailOverviewView.swift
@@ -11,13 +11,13 @@ import OggDecoder
 import SwiftData
 
 struct PokemonDetailOverviewView: View {
-    @Environment(\.modelContext) var modelContext
-    @Query var favoritedPokemon: [FavoriteModel]
+    @Environment(\.modelContext) private var modelContext
+    @Query private var favoritedPokemon: [FavoriteModel]
     @Binding var showingIrochiPortrait: Bool
     @Binding var isFavorite: Bool
     let localization: Locale
     
-    @State var audioPlayer: AVAudioPlayer!
+    @State private var audioPlayer: AVAudioPlayer!
     
     let viewModel: PokemonDetailViewModel
     

--- a/PokedexProject/View/DetailView/PokemonDetailViewModel.swift
+++ b/PokedexProject/View/DetailView/PokemonDetailViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 @Observable
-class PokemonDetailViewModel {
+final class PokemonDetailViewModel {
     private let apiService: some PokemonDetailUseCase = PokemonAPIService()
     private(set) var pokemonData: PokemonDetailData?
     private(set) var pokemonSpeciesData: PokemonSpeciesData?

--- a/PokedexProject/View/DetailView/PokemonFlavorTextSheetView.swift
+++ b/PokedexProject/View/DetailView/PokemonFlavorTextSheetView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct PokemonFlavorTextSheetView: View {
     
-    @Environment (\.dismiss) var dismiss
+    @Environment (\.dismiss) private var dismiss
     @State private var showingFlavorText: [FlavorText] = []
     @Binding var locale: Locale?
     

--- a/PokedexProject/View/DetailView/PokemonMoveModalView.swift
+++ b/PokedexProject/View/DetailView/PokemonMoveModalView.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct PokemonMoveModalView: View {
     
-    @Environment (\.dismiss) var dismiss
-    @State var moveData: PokemonMoveDetailExtended?
+    @Environment (\.dismiss) private var dismiss
+    @State private var moveData: PokemonMoveDetailExtended?
     
     let moveDetail: PokemonMoveDetail
     let gridItem: [GridItem] = [

--- a/PokedexProject/View/DetailView/PokemonSpriteView.swift
+++ b/PokedexProject/View/DetailView/PokemonSpriteView.swift
@@ -13,9 +13,10 @@ struct PokemonSpriteView: View {
     @State private var roll: Double = 0.0
     @State private var pitch: Double = 0.0
     
-    let motionManager: CMMotionManager = CMMotionManager()
+    private let motionManager: CMMotionManager = CMMotionManager()
     let imageUrl: URL
     let viewWidth: CGFloat
+    
     var body: some View {
         AsyncImage(url: imageUrl) { image in
             ZStack {

--- a/PokedexProject/View/EntryView/EntryView.swift
+++ b/PokedexProject/View/EntryView/EntryView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct EntryView: View {
-    
     @State private var searchKeyword: String = ""
     @State private var searchedPokemon: [PokemonListObject]?
     @State private var isSearching: Bool = false
@@ -50,6 +49,11 @@ struct EntryView: View {
                     }
                 }
             }
+            .task {
+                if viewModel.initialFetchedResult.isEmpty {
+                    await viewModel.fetch()
+                }
+            }
         }
     }
     
@@ -89,5 +93,5 @@ extension EntryView {
 }
 
 #Preview {
-    EntryView(viewModel: EntryViewModel(limit: 30, offset: 0), startFrom: 0)
+    EntryView(viewModel: EntryViewModel(limit: 30, offset: 0, service: PokemonAPIService()), startFrom: 0)
 }

--- a/PokedexProject/View/EntryView/EntryView.swift
+++ b/PokedexProject/View/EntryView/EntryView.swift
@@ -11,6 +11,7 @@ struct EntryView: View {
     @State private var searchKeyword: String = ""
     @State private var searchedPokemon: [PokemonListObject]?
     @State private var isSearching: Bool = false
+    @State private var isLoading = false
     
     private let viewModel: EntryViewModel
     private let startFrom: Int
@@ -29,17 +30,21 @@ struct EntryView: View {
         VStack {
             //MARK: 비검색중 화면
             ScrollView {
-                ForEach(0..<viewModel.pokeList.count, id: \.self) { i in
-                    LazyVStack {
-                        NavigationLink {
-                            PokemonDetailView(pokeData: viewModel.pokeList[i], endpoint: viewModel.pokeList[i].url)
-                        } label: {
-                            EntryViewCell(index: i + startFrom, pokemonName: viewModel.pokeList[i].name)
-                                .frame(height: 140)
+                if isLoading {
+                    ProgressView()
+                } else {
+                    ForEach(0..<viewModel.pokeList.count, id: \.self) { i in
+                        LazyVStack {
+                            NavigationLink {
+                                PokemonDetailView(pokeData: viewModel.pokeList[i], endpoint: viewModel.pokeList[i].url)
+                            } label: {
+                                EntryViewCell(index: i + startFrom, pokemonName: viewModel.pokeList[i].name)
+                                    .frame(height: 140)
+                            }
+                            .backgroundStyle(Color("backgroundColor"))
                         }
-                        .backgroundStyle(Color("backgroundColor"))
+                        .padding(.vertical, -4)
                     }
-                    .padding(.vertical, -4)
                 }
             }
             .navigationBarTitleDisplayMode(.inline)
@@ -59,7 +64,9 @@ struct EntryView: View {
             }
             .task {
                 if viewModel.initialFetchedResult.isEmpty {
+                    isLoading = true
                     await viewModel.fetch()
+                    isLoading = false
                 }
             }
         }

--- a/PokedexProject/View/EntryView/EntryView.swift
+++ b/PokedexProject/View/EntryView/EntryView.swift
@@ -12,10 +12,18 @@ struct EntryView: View {
     @State private var searchedPokemon: [PokemonListObject]?
     @State private var isSearching: Bool = false
     
-    var viewModel: EntryViewModel
-    let startFrom: Int
+    private let viewModel: EntryViewModel
+    private let startFrom: Int
     
-    let gridItems: [GridItem] = [GridItem(.adaptive(minimum: 100, maximum: .infinity))]
+    private let gridItems: [GridItem] = [GridItem(.adaptive(minimum: 100, maximum: .infinity))]
+    
+    init(
+        viewModel: EntryViewModel,
+        startFrom: Int
+    ) {
+        self.viewModel = viewModel
+        self.startFrom = startFrom
+    }
     
     var body: some View {
         VStack {

--- a/PokedexProject/View/EntryView/EntryViewCell.swift
+++ b/PokedexProject/View/EntryView/EntryViewCell.swift
@@ -8,13 +8,11 @@
 import SwiftUI
 
 struct EntryViewCell: View {
-    @StateObject var pokemonPortraitDispatcher = PokemonPortraitDispatcher()
-    @State var portraitOffsetX: CGFloat = 50.0
-    @State var cellOpacity: CGFloat = 0.0
+    @StateObject private var pokemonPortraitDispatcher = PokemonPortraitDispatcher()
+    @State private var portraitOffsetX: CGFloat = 50.0
+    @State private var cellOpacity: CGFloat = 0.0
     
-    let index: Int
-    let pokemonName: String
-    var adjustedTextColor: UIColor {
+    private var adjustedTextColor: UIColor {
         var h: CGFloat = 0.0,
             s: CGFloat = 0.0,
             b: CGFloat = 0.0,
@@ -26,6 +24,9 @@ struct EntryViewCell: View {
         }
         return UIColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
     }
+    
+    let index: Int
+    let pokemonName: String
     
     var body: some View {
         ZStack {

--- a/PokedexProject/View/EntryView/EntryViewModel.swift
+++ b/PokedexProject/View/EntryView/EntryViewModel.swift
@@ -9,14 +9,14 @@ import Foundation
 import Observation
 
 @Observable
-class EntryViewModel {
+final class EntryViewModel {
     private let service: any EntryUseCase
     private(set) var pokeList: [PokemonListObject] = []
     private(set) var initialFetchedResult: [PokemonListObject] = []
     
-    var urlString: String
-    var limit: Int
-    var offset: Int
+    private let urlString: String
+    private let limit: Int
+    private let offset: Int
     
     init(
         urlString: String = "",

--- a/PokedexProject/View/EntryView/EntryViewModel.swift
+++ b/PokedexProject/View/EntryView/EntryViewModel.swift
@@ -10,7 +10,7 @@ import Observation
 
 @Observable
 class EntryViewModel {
-    private let apiUseCase: some EntryUseCase = PokemonAPIService()
+    private let service: any EntryUseCase
     private(set) var pokeList: [PokemonListObject] = []
     private(set) var initialFetchedResult: [PokemonListObject] = []
     
@@ -18,18 +18,20 @@ class EntryViewModel {
     var limit: Int
     var offset: Int
     
-    init(urlString: String = "", limit: Int, offset: Int) {
+    init(
+        urlString: String = "",
+        limit: Int,
+        offset: Int,
+        service: any EntryUseCase
+    ) {
         self.limit = limit
         self.offset = offset
         self.urlString = "https://pokeapi.co/api/v2/pokemon?limit=\(limit)&offset=\(offset)"
-        
-        Task {
-            await initialFetch()
-        }
+        self.service = service
     }
     
-    @MainActor func initialFetch() async {
-        let result = await apiUseCase.fetch(with: urlString)
+    func fetch() async {
+        let result = await service.fetch(with: urlString)
         
         pokeList = result
         initialFetchedResult = result

--- a/PokedexProject/View/MainGridView.swift
+++ b/PokedexProject/View/MainGridView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import CoreMotion
 
 struct MainGridView: View {
-    
+    @Environment(\.pokemonAPIService) private var service
     private var gridItems: [GridItem] = [
         GridItem(.flexible(minimum: 100, maximum: .infinity)),
         GridItem(.flexible(minimum: 100, maximum: .infinity))
@@ -30,7 +30,7 @@ struct MainGridView: View {
             ScrollView {
                 LazyVGrid(columns: gridItems) {
                     NavigationLink {
-                        EntryView(viewModel: EntryViewModel(limit: 151, offset: 0),
+                        EntryView(viewModel: EntryViewModel(limit: 151, offset: 0, service: service),
                                   startFrom: 0)
                     } label: {
                         GenerationCellView(listRangeText: "0001-\n0151",
@@ -41,7 +41,7 @@ struct MainGridView: View {
                     }
                     
                     NavigationLink {
-                        EntryView(viewModel: EntryViewModel(limit: 100, offset: 151),
+                        EntryView(viewModel: EntryViewModel(limit: 100, offset: 151, service: service),
                                   startFrom: 151)
                     } label: {
                         GenerationCellView(listRangeText: "0152-\n0251",
@@ -52,7 +52,7 @@ struct MainGridView: View {
                     }
                     
                     NavigationLink {
-                        EntryView(viewModel: EntryViewModel(limit: 135, offset: 251),
+                        EntryView(viewModel: EntryViewModel(limit: 135, offset: 251, service: service),
                                   startFrom: 251)
                     } label: {
                         GenerationCellView(listRangeText: "0252-\n0386",
@@ -63,7 +63,7 @@ struct MainGridView: View {
                     }
                     
                     NavigationLink {
-                        EntryView(viewModel: EntryViewModel(limit: 107, offset: 386),
+                        EntryView(viewModel: EntryViewModel(limit: 107, offset: 386, service: service),
                                   startFrom: 386)
                     } label: {
                         GenerationCellView(listRangeText: "0387-\n0493",
@@ -74,7 +74,7 @@ struct MainGridView: View {
                     }
                     
                     NavigationLink {
-                        EntryView(viewModel: EntryViewModel(limit: 156, offset: 493),
+                        EntryView(viewModel: EntryViewModel(limit: 156, offset: 493, service: service),
                                   startFrom: 493)
                     } label: {
                         GenerationCellView(listRangeText: "0494-\n0649",
@@ -85,7 +85,7 @@ struct MainGridView: View {
                     }
                     
                     NavigationLink {
-                        EntryView(viewModel: EntryViewModel(limit: 72, offset: 649),
+                        EntryView(viewModel: EntryViewModel(limit: 72, offset: 649, service: service),
                                   startFrom: 649)
                     } label: {
                         GenerationCellView(listRangeText: "0650-\n0721",
@@ -96,7 +96,7 @@ struct MainGridView: View {
                     }
                     
                     NavigationLink {
-                        EntryView(viewModel: EntryViewModel(limit: 88, offset: 721),
+                        EntryView(viewModel: EntryViewModel(limit: 88, offset: 721, service: service),
                                   startFrom: 721)
                     } label: {
                         GenerationCellView(listRangeText: "0722-\n0809",
@@ -107,7 +107,7 @@ struct MainGridView: View {
                     }
                     
                     NavigationLink {
-                        EntryView(viewModel: EntryViewModel(limit: 96, offset: 809),
+                        EntryView(viewModel: EntryViewModel(limit: 96, offset: 809, service: service),
                                   startFrom: 809)
                     } label: {
                         GenerationCellView(listRangeText: "0810-\n0905",
@@ -118,7 +118,7 @@ struct MainGridView: View {
                     }
                     
                     NavigationLink {
-                        EntryView(viewModel: EntryViewModel(limit: 120, offset: 905),
+                        EntryView(viewModel: EntryViewModel(limit: 120, offset: 905, service: service),
                                   startFrom: 905)
                     } label: {
                         GenerationCellView(listRangeText: "0906-\n1025",

--- a/PokedexProject/View/MainGridView.swift
+++ b/PokedexProject/View/MainGridView.swift
@@ -188,7 +188,6 @@ struct GenerationCellView: View {
                 guard let validMotion = motion else { return }
                 roll = validMotion.attitude.roll
                 pitch = validMotion.attitude.pitch
-//                print("roll: \(roll * 20) / pitch: \(pitch * 20)")
             }
         }
     }

--- a/PokedexProject/View/MainView.swift
+++ b/PokedexProject/View/MainView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct MainView: View {
+    @Environment(\.pokemonAPIService) private var service
+    
     var body: some View {
         TabView {
             MainGridView()
@@ -34,7 +36,7 @@ struct MainView: View {
                     )
                 }
             
-            SearchView()
+            SearchView(viewModel: EntryViewModel(limit: 1100, offset: 0, service: service))
                 .tabItem {
                     Label(
                         title: {

--- a/PokedexProject/View/SearchView/SearchView.swift
+++ b/PokedexProject/View/SearchView/SearchView.swift
@@ -13,7 +13,7 @@ struct SearchView: View {
     @FocusState private var searchFocused
     let localedSearchViewModel: LocaledSearchViewModel = LocaledSearchViewModel()
 //    let searchViewModel: SearchViewModel = SearchViewModel()
-    let viewModel: EntryViewModel = EntryViewModel(limit: 1100, offset: 0)
+    let viewModel: EntryViewModel
     
     var body: some View {
         NavigationStack {
@@ -75,5 +75,5 @@ struct SearchView: View {
 }
 
 #Preview {
-    SearchView()
+    SearchView(viewModel: EntryViewModel(limit: 1100, offset: 0, service: PokemonAPIService()))
 }

--- a/PokedexProject/View/SearchView/SearchViewModel.swift
+++ b/PokedexProject/View/SearchView/SearchViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 @Observable
-class LocaledSearchViewModel {
+final class LocaledSearchViewModel {
     private(set) var searchResult: [PokemonListObject] = []
     private(set) var searchResultViewCell: [SearchViewCell] = []
     private(set) var pokemonLocaleList: [PokemonLocalNameModel] = []


### PR DESCRIPTION
# Existing Issues
기존 대부분의 view model들이 사용하는 의존성인 `service`객체에 대한 문제가 있었습니다. 모두 동일한 인스턴스를 사용하는게 옳은 방향 같으나, 각 view model들은 모두 다른 인스턴스를 주입 받아 왔습니다. 아래는 각 `EntryViewModel`이 가지는 `service`객체의 인스턴스 정보입니다. 모두 다른 메모리 영역을 차지하는 인스턴스임을 알 수 있습니다.
<img width="1723" alt="before" src="https://github.com/hellotunamayo/PokedexProject/assets/26710036/e9abe969-c99a-43b5-941e-2124f09eb596">

# Proposed Solution
## Using Environment
SwiftUI에는 `Environment`라는 의존성 주입 컨테이너와 비슷한 역할을 하는 객체가 있습니다. 사용은 단순하게 key 객체를 만들고 `EnvironmentKey` 프로토콜을 채택하면 됩니다. 이 프로토콜은 기본적으로 `defaultValue`를 요구합니다. 이는 기본적으로 사용한 객체입니다.
```swift
import SwiftUI

struct PokemonAPIServiceEnvironmentKey: EnvironmentKey {
    static var defaultValue: PokemonAPIService = .init()
}
```
마지막으로 `EnvironmentValues`에서 resolve하거나 resolve된 객체를 가져오는 부분을 추가해주면 됩니다.
```swift
extension EnvironmentValues {
    var pokemonAPIService: PokemonAPIService {
        get { self[PokemonAPIServiceEnvironmentKey.self] }
        set { self[PokemonAPIServiceEnvironmentKey.self] = newValue }
    }
}
```

사용은 `Environment` 프로퍼티 래퍼를 사용하여 해당 객체에 대해 접근하면 됩니다.
```swift
struct MainView: View {
    @Environment(\.pokemonAPIService) private var service
    ....
}
```

# Results
<img width="1723" alt="after" src="https://github.com/hellotunamayo/PokedexProject/assets/26710036/a7c87a2c-e050-46a4-b790-ae5f5351a7bf">
다시한번 메모리 그래프를 통해 확인해보면, 이번에는 모두 동일한 인스턴스에 의존하고 있음을 알 수 있습니다.

Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/hellotunamayo/PokedexProject/assets/26710036/2b0f6f39-8318-4a6a-9304-b806dc8719be)  |  ![](https://github.com/hellotunamayo/PokedexProject/assets/26710036/ca9589c2-6d53-42d3-9856-b8372a7213b9)

메모리 그래프 파일을 통해 확인해보니 당장은 그리 큰 변화는 없으나 약 1mb 정도의 메모리가 절약이 되었습니다.

# ETC
추가적으로, 주요 PR내용과는 무관하지만 네트워킹을 하는 동안에는 사용자에게 프로그래스 뷰를 보여주는 부분도 추가했습니다. 이 부분은 000134888856d609a1e64ffd88be3dfa8633ef99 여기 커밋 내용입니다.
Related: #26 